### PR TITLE
Update dependencies and add `b.elapsed()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ ok ~1.15 s (1 s + 152152365 ns)
 Add a new benchmark. `run` is called with a benchmark object, `b` that has the following methods
 
 * `b.start()` - Start the benchmark. If not called the bench will be tracked from the beginning of the function.
-* `b.end()` - End the benchmark.
+* `b.end()` - End the benchmark. Returns the time elapsed in milliseconds.
+* `b.elapsed()` - Return the time elapsed in milliseconds.
 * `b.error(err)` - Benchmark failed. Report error.
 * `b.log(msg)` - Log out a message
 

--- a/compare.js
+++ b/compare.js
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
 
-var fs = require('fs')
-var parse = require('./parse')
-var prettyHrtime = require('pretty-hrtime')
-var chalk = require('chalk')
+const fs = require('fs')
+const prettyHrtime = require('pretty-hrtime')
+const chalk = require('chalk')
+const parse = require('./parse')
 
-var grace = 0.05 // 5% grace
-var a = parse(fs.readFileSync(process.argv[2]))
-var b = parse(fs.readFileSync(process.argv[3]))
+const grace = 0.05 // 5% grace
+const a = parse(fs.readFileSync(process.argv[2]))
+const b = parse(fs.readFileSync(process.argv[3]))
 
-var upper = 1 + grace
-var lower = 1 - grace
+const upper = 1 + grace
+const lower = 1 - grace
 
-var mapA = toMap(a)
-var mapB = toMap(b)
-var list = []
+const mapA = toMap(a)
+const mapB = toMap(b)
+const list = []
 
 a.benchmarks.forEach(function (bench) {
   compareBench(bench, mapB)
@@ -25,27 +25,27 @@ b.benchmarks.forEach(function (bench) {
 })
 
 write('NANOBENCH version 2', '|', 'NANOBENCH version 2')
-write('> ' + a.command,      '|', '> ' + b.command)
-write('',                    '|', '')
+write('> ' + a.command, '|', '> ' + b.command)
+write('', '|', '')
 
 list.forEach(function (bench) {
-  var left = bench
-  var right = bench.other
+  let left = bench
+  let right = bench.other
 
   if (mapB[left.name] === left) {
-    var tmp = left
+    const tmp = left
     left = right
     right = tmp
   }
 
-  var sep = '='
+  let sep = '='
   if (left.winner) sep = '<'
   if (right && right.winner) sep = '>'
 
   write('# ' + left.name, sep, right && '# ' + right.name)
 
-  var len = Math.max(left.output.length, right ? right.output.length : 0)
-  for (var i = 0; i < len; i++) {
+  const len = Math.max(left.output.length, right ? right.output.length : 0)
+  for (let i = 0; i < len; i++) {
     write(left.output[i] && '# ' + left.output[i], sep, right.output[i] && '# ' + right.output[i])
   }
 
@@ -53,8 +53,8 @@ list.forEach(function (bench) {
   write('', '|', '')
 })
 
-var last = compare(a.time, b.time)
-var sep = last === 1 ? '>' : last === -1 ? '<' : '='
+const last = compare(a.time, b.time)
+const sep = last === 1 ? '>' : last === -1 ? '<' : '='
 
 write('all benchmarks completed', sep, 'all benchmarks completed')
 write(result(a), sep, result(b))
@@ -87,24 +87,24 @@ function write (a, sep, b) {
   }
   if (sep === '=') sep = '==='
 
-  console.log(a + sep + '   ' +b)
+  console.log(a + sep + '   ' + b)
 }
 
 function compareBench (bench, map) {
-  var other = map[bench.name]
+  const other = map[bench.name]
   if (!other) return
   if (list.indexOf(other) > -1) return
 
-  var cmp = compare(bench.time, other.time)
+  const cmp = compare(bench.time, other.time)
 
   bench.other = other
   list.push(bench)
 
-  var winner = null
+  let winner = null
   if (cmp === 1) winner = other
   if (cmp === -1) winner = bench
 
-  var loser = winner === bench ? other : bench
+  const loser = winner === bench ? other : bench
 
   if (winner) {
     winner.winner = true
@@ -113,14 +113,14 @@ function compareBench (bench, map) {
 }
 
 function compare (a, b) {
-  var pct = (a[0] * 1e9 + a[1]) / (b[0] * 1e9 + b[1])
+  const pct = (a[0] * 1e9 + a[1]) / (b[0] * 1e9 + b[1])
   if (pct > upper) return 1
   if (pct < lower) return -1
   return 0
 }
 
 function toMap (output) {
-  var map = {}
+  const map = {}
   output.benchmarks.forEach(function (b) {
     map[b.name] = b
   })

--- a/example.js
+++ b/example.js
@@ -1,12 +1,12 @@
-var bench = require('./')
+const bench = require('./')
 
 bench('sha1 200.000 times', function (b) {
-  var crypto = require('crypto')
-  var data = new Buffer('hello world')
+  const crypto = require('crypto')
+  let data = Buffer.from('hello world')
 
   b.start()
 
-  for (var i = 0; i < 200000; i++) {
+  for (let i = 0; i < 200000; i++) {
     data = crypto.createHash('sha1').update(data).digest()
   }
 
@@ -14,12 +14,12 @@ bench('sha1 200.000 times', function (b) {
 })
 
 bench('sha256 200.000 times', function (b) {
-  var crypto = require('crypto')
-  var data = new Buffer('hello world')
+  const crypto = require('crypto')
+  let data = Buffer.from('hello world')
 
   b.start()
 
-  for (var i = 0; i < 200000; i++) {
+  for (let i = 0; i < 200000; i++) {
     data = crypto.createHash('sha256').update(data).digest()
   }
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function toMillis (hr) {
 }
 
 function benchmark (name, fn, only) {
-  process.nextTick(async function () {
+  process.nextTick(function () {
     if (one && !only) return
     if (runs === 0) {
       console.log('NANOBENCH version 2\n> ' + command() + '\n')

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "Simple benchmarking tool with TAP-like output that is easy to parse",
   "main": "index.js",
   "dependencies": {
-    "browser-process-hrtime": "^0.1.2",
-    "chalk": "^1.1.3",
-    "mutexify": "^1.1.0",
+    "chalk": "^5.0.1",
+    "mutexify": "^1.4.0",
     "pretty-hrtime": "^1.0.2"
   },
   "devDependencies": {
-    "standard": "^8.5.0"
+    "standard": "^17.0.0"
   },
   "scripts": {
     "test": "standard"

--- a/parse.js
+++ b/parse.js
@@ -1,7 +1,5 @@
-module.exports = parse
-
-function parse (data) {
-  var lines = data.toString().trim().split('\n')
+module.exports = function parse (data) {
+  const lines = data.toString().trim().split('\n')
     .map(function (line) {
       return line.trim()
     })
@@ -9,10 +7,10 @@ function parse (data) {
       return line
     })
 
-  var output = {}
+  const output = {}
 
   while (lines.length && !output.type) {
-    var header = lines.shift().match(/^NANOBENCH(?: version (\d+))?$/)
+    const header = lines.shift().match(/^NANOBENCH(?: version (\d+))?$/)
     if (!header) continue
     output.type = 'NANOBENCH'
     output.version = Number(header[1] || 1)
@@ -30,17 +28,17 @@ function parse (data) {
   output.error = null
   output.time = null
 
-  var benchmark = null
+  let benchmark = null
 
   while (lines.length) {
-    var next = lines.shift()
+    const next = lines.shift()
     if (next[0] === '>') {
       output.command = next.slice(1).trim()
       continue
     }
 
     if (!benchmark && next[0] === '#') {
-      benchmark = {name: null, output: [], error: null, time: null}
+      benchmark = { name: null, output: [], error: null, time: null }
       benchmark.name = next.slice(1).trim()
       continue
     }
@@ -80,10 +78,10 @@ function parse (data) {
 }
 
 function time (line) {
-  var i = line.lastIndexOf('(')
-  var j = line.lastIndexOf(')')
+  const i = line.lastIndexOf('(')
+  const j = line.lastIndexOf(')')
   if (i === -1 || j === -1 || j < i) throw new Error('Could not parse benchmark time')
-  var parsed = line.slice(i + 1, j).match(/^(\d+)\s*s\s*\+\s*(\d+)\s*ns$/)
+  const parsed = line.slice(i + 1, j).match(/^(\d+)\s*s\s*\+\s*(\d+)\s*ns$/)
   if (!parsed) throw new Error('Could not parse benchmark time')
   return [Number(parsed[1]), Number(parsed[2])]
 }

--- a/run.js
+++ b/run.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
-var bench = require('./')
-var path = require('path')
+const path = require('path')
 
 global.__NANOBENCH__ = require.resolve('./')
 
-for (var i = 2; i < process.argv.length; i++) require(path.join(process.cwd(), process.argv[i]))
+for (let i = 2; i < process.argv.length; i++) require(path.join(process.cwd(), process.argv[i]))


### PR DESCRIPTION
`b.elapsed()` is useful for printing timing related information about the benchmark without the need for an extra timer.